### PR TITLE
[feat/refactor] 전시정보 상세페이지 api, 소통/리뷰에 전시회id 추가, 진행예정인 전시 -> 무료 전시로 변경

### DIFF
--- a/src/main/java/com/backend/Artview/domain/communication/Repository/CommunicationsRepository.java
+++ b/src/main/java/com/backend/Artview/domain/communication/Repository/CommunicationsRepository.java
@@ -42,4 +42,6 @@ public interface CommunicationsRepository extends JpaRepository<Communications,L
                     "ORDER BY co.createDate desc"
     )
     Slice<Communications> findFollowCommunicationsByCursorTopBy(@Param("cursor") Long cursor, @Param("userId") Long userId, PageRequest pageRequest);
+
+    List<Communications> findAllByCrawlingExhibitionId(Long exhibitionId);
 }

--- a/src/main/java/com/backend/Artview/domain/communication/domain/Communications.java
+++ b/src/main/java/com/backend/Artview/domain/communication/domain/Communications.java
@@ -1,6 +1,7 @@
 package com.backend.Artview.domain.communication.domain;
 
 import com.backend.Artview.domain.communication.dto.request.CommunicationSaveRequestDto;
+import com.backend.Artview.domain.exhibition.domain.CrawlingExhibition;
 import com.backend.Artview.domain.users.domain.Users;
 import com.backend.Artview.global.domain.BaseEntity;
 import jakarta.persistence.*;
@@ -51,8 +52,12 @@ public class Communications extends BaseEntity {
     @OneToMany(mappedBy = "communications",fetch = FetchType.LAZY)
     private List<Scrap> scrapList = new ArrayList<>();
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "crawling_exhibition_id")
+    private CrawlingExhibition crawlingExhibition;
 
-    public static Communications toEntity(CommunicationSaveRequestDto dto, Users users) {
+
+    public static Communications toEntity(CommunicationSaveRequestDto dto, Users users, CrawlingExhibition crawlingExhibition) {
         return Communications.builder()
                 .name(dto.name())
                 .rate(dto.rate())
@@ -60,6 +65,7 @@ public class Communications extends BaseEntity {
                 .gallery(dto.gallery())
                 .content(dto.content())
                 .users(users)
+                .crawlingExhibition(crawlingExhibition)
                 .build();
     }
 

--- a/src/main/java/com/backend/Artview/domain/communication/dto/request/CommunicationSaveRequestDto.java
+++ b/src/main/java/com/backend/Artview/domain/communication/dto/request/CommunicationSaveRequestDto.java
@@ -13,6 +13,7 @@ public record CommunicationSaveRequestDto(
         Map<String,String> imageAndTitle,
 //        List<String> imageTitle,
         String content, //글쓰기 내용
-        List<String> keyword //감상 키워드
+        List<String> keyword, //감상 키워드
+        Long exhibitionId
 ) {
 }

--- a/src/main/java/com/backend/Artview/domain/communication/service/CommunicationsServiceImpl.java
+++ b/src/main/java/com/backend/Artview/domain/communication/service/CommunicationsServiceImpl.java
@@ -10,6 +10,8 @@ import com.backend.Artview.domain.communication.dto.response.CommunicationsMainR
 import com.backend.Artview.domain.communication.dto.response.DetailCommunicationsCommentResponseDto;
 import com.backend.Artview.domain.communication.dto.response.DetailCommunicationsContentResponseDto;
 import com.backend.Artview.domain.communication.exception.CommunicationException;
+import com.backend.Artview.domain.exhibition.domain.CrawlingExhibition;
+import com.backend.Artview.domain.exhibition.repository.CrawlingExhibitionRepository;
 import com.backend.Artview.domain.myReviews.domain.MyReviews;
 import com.backend.Artview.domain.myReviews.domain.MyReviewsContents;
 import com.backend.Artview.domain.myReviews.exception.MyReviewsException;
@@ -41,6 +43,7 @@ public class CommunicationsServiceImpl implements CommunicationsService {
     private final UsersRepository usersRepository;
     private final CommentRepository commentRepository;
     private final LikeRepository likeRepository;
+    private final CrawlingExhibitionRepository crawlingExhibitionRepository;
     private final PaginationUtil paginationUtil;
 
     private final int DEFAULT_PAGE_SIZE = 2;
@@ -70,7 +73,9 @@ public class CommunicationsServiceImpl implements CommunicationsService {
     @Transactional
     public Long saveCommunications(CommunicationSaveRequestDto dto, Long userId) {
         verifyMyReviewsIdExists(dto.myReviewId());
-        Communications communications = Communications.toEntity(dto, findUsersByUserId(userId));
+        CrawlingExhibition crawlingExhibition = findCrawlingExhibition(dto.exhibitionId());
+
+        Communications communications = Communications.toEntity(dto, findUsersByUserId(userId), crawlingExhibition);
 
         List<CommunicationImages> communicationImagesList = dto.imageAndTitle().entrySet().stream().map(image -> CommunicationImages.toEntity(image.getKey(), image.getValue(), communications)).toList();
         List<CommunicationsKeyword> communicationsKeywordList = dto.keyword().stream().map(keyword -> CommunicationsKeyword.toEntity(keyword, communications)).toList();
@@ -166,6 +171,10 @@ public class CommunicationsServiceImpl implements CommunicationsService {
     @Transactional
     public CommunicationsMainResponseDto findFollowCommunications(Long cursor, Long userId) {
         return findCommunicationsByType(cursor, userId, CommunicationsType.FOLLOW);
+    }
+
+    private CrawlingExhibition findCrawlingExhibition(Long exhibitionId){
+        return crawlingExhibitionRepository.findById(exhibitionId).orElse(null);
     }
 
     private CommunicationsMainResponseDto findCommunicationsByType(Long cursor, Long userId, CommunicationsType type) {

--- a/src/main/java/com/backend/Artview/domain/exhibition/controller/ExhibitionController.java
+++ b/src/main/java/com/backend/Artview/domain/exhibition/controller/ExhibitionController.java
@@ -1,5 +1,7 @@
 package com.backend.Artview.domain.exhibition.controller;
 
+import com.backend.Artview.domain.exhibition.dto.response.ExhibitionDetailInfoResponseDto;
+import com.backend.Artview.domain.exhibition.dto.response.ExhibitionDetailReviewResponseDto;
 import com.backend.Artview.domain.exhibition.dto.response.ExhibitionResponseDto;
 import com.backend.Artview.domain.exhibition.service.ExhibitionService;
 import com.backend.Artview.domain.exhibition.service.ExhibitionServiceImpl;
@@ -29,5 +31,15 @@ public class ExhibitionController {
     @GetMapping("/ongoing/{cursor}")
     public ExhibitionResponseDto findOngoingExhibition(@PathVariable Long cursor) {
         return exhibitionService.findOngoingExhibition(cursor);
+    }
+
+    @GetMapping("/detail/info/{exhibitionId}")
+    public ExhibitionDetailInfoResponseDto findExhibitionDetailInfo(@PathVariable Long exhibitionId) {
+        return exhibitionService.findExhibitionDetailInfo(exhibitionId);
+    }
+
+    @GetMapping("/detail/review/{exhibitionId}")
+    public List<ExhibitionDetailReviewResponseDto> findExhibitionDetailReview(@PathVariable Long exhibitionId) {
+       return exhibitionService.findExhibitionDetailReview(exhibitionId);
     }
 }

--- a/src/main/java/com/backend/Artview/domain/exhibition/domain/CrawlingExhibition.java
+++ b/src/main/java/com/backend/Artview/domain/exhibition/domain/CrawlingExhibition.java
@@ -1,11 +1,14 @@
 package com.backend.Artview.domain.exhibition.domain;
 
+import com.backend.Artview.domain.communication.domain.Communications;
+import com.backend.Artview.domain.myReviews.domain.MyReviews;
 import com.backend.Artview.global.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicUpdate;
 
-import java.util.Date;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "CrawlingExhibition")
@@ -42,6 +45,12 @@ public class CrawlingExhibition extends BaseEntity {
 
     @Column(name = "progress_type")
     private String progressType;
+
+    @OneToMany(mappedBy = "crawlingExhibition" ,fetch = FetchType.LAZY)
+    private List<MyReviews> myReviewsList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "crawlingExhibition", fetch = FetchType.LAZY)
+    private List<Communications> communicationsList = new ArrayList<>();
 
     public void updateProgress(String progressType) {
         this.progressType = progressType;

--- a/src/main/java/com/backend/Artview/domain/exhibition/dto/response/ExhibitionDetailInfoResponseDto.java
+++ b/src/main/java/com/backend/Artview/domain/exhibition/dto/response/ExhibitionDetailInfoResponseDto.java
@@ -1,0 +1,32 @@
+package com.backend.Artview.domain.exhibition.dto.response;
+
+import com.backend.Artview.domain.exhibition.domain.CrawlingExhibition;
+import lombok.Builder;
+
+import java.util.List;
+
+import static com.backend.Artview.domain.exhibition.domain.ExhibitionType.FREE;
+import static com.backend.Artview.domain.exhibition.domain.ExhibitionType.ONGOING;
+import static com.backend.Artview.global.util.StringUtil.removeTextFromSentence;
+
+@Builder
+public record ExhibitionDetailInfoResponseDto(
+        ExhibitionInfo exhibitionInfo,
+        List<String> operatingHours,
+        boolean isOngoing,
+        String locationLink
+) {
+    public static ExhibitionDetailInfoResponseDto of(CrawlingExhibition crawlingExhibition) {
+        return ExhibitionDetailInfoResponseDto.builder()
+                .exhibitionInfo(ExhibitionInfo.of(crawlingExhibition))
+                .operatingHours(crawlingExhibition.getOperatingHours().isEmpty() ?
+                        null : removeTextFromSentence(crawlingExhibition.getOperatingHours(), "\n"))
+                .isOngoing(checkExhibitionProgressType(crawlingExhibition.getProgressType()))
+                .locationLink(crawlingExhibition.getLocationLink())
+                .build();
+    }
+
+    private static boolean checkExhibitionProgressType(String progressType) {
+        return (progressType.equals(ONGOING.getCode()) || progressType.equals(FREE.getCode()));
+    }
+}

--- a/src/main/java/com/backend/Artview/domain/exhibition/dto/response/ExhibitionDetailReviewResponseDto.java
+++ b/src/main/java/com/backend/Artview/domain/exhibition/dto/response/ExhibitionDetailReviewResponseDto.java
@@ -1,0 +1,23 @@
+package com.backend.Artview.domain.exhibition.dto.response;
+
+import com.backend.Artview.domain.communication.domain.Communications;
+import lombok.Builder;
+
+@Builder
+public record ExhibitionDetailReviewResponseDto(
+        Long userId,
+        String userName,
+        String userImageUrl,
+        String rate,
+        String content
+) {
+    public static ExhibitionDetailReviewResponseDto of(Communications communications) {
+        return ExhibitionDetailReviewResponseDto.builder()
+                .userId(communications.getUsers().getId())
+                .userName(communications.getUsers().getName())
+                .userImageUrl(communications.getUsers().getUserImage())
+                .rate(communications.getRate())
+                .content(communications.getContent())
+                .build();
+    }
+}

--- a/src/main/java/com/backend/Artview/domain/exhibition/exception/ExhibitionErrorCode.java
+++ b/src/main/java/com/backend/Artview/domain/exhibition/exception/ExhibitionErrorCode.java
@@ -1,0 +1,18 @@
+package com.backend.Artview.domain.exhibition.exception;
+
+import com.backend.Artview.global.code.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+@Getter
+public enum ExhibitionErrorCode implements BaseErrorCode {
+    EXHIBITION_NOT_FOUND(HttpStatus.NOT_FOUND,404,"id와 일치하는 전시정보를 찾을 수 없습니다."),
+    EXHIBITION_REVIEWS_NOT_FOUND(HttpStatus.NOT_FOUND,404,"전시 id와 일치하는 리뷰를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final int statusCode;
+    private final String message;
+
+}

--- a/src/main/java/com/backend/Artview/domain/exhibition/exception/ExhibitionException.java
+++ b/src/main/java/com/backend/Artview/domain/exhibition/exception/ExhibitionException.java
@@ -1,0 +1,15 @@
+package com.backend.Artview.domain.exhibition.exception;
+
+import com.backend.Artview.global.exception.ApplicationException;
+import lombok.Getter;
+
+@Getter
+public class ExhibitionException extends ApplicationException {
+    private final ExhibitionErrorCode exhibitionErrorCode;
+
+    public ExhibitionException(ExhibitionErrorCode exhibitionErrorCode) {
+        super(exhibitionErrorCode);
+        this.exhibitionErrorCode = exhibitionErrorCode;
+    }
+
+}

--- a/src/main/java/com/backend/Artview/domain/exhibition/service/ExhibitionService.java
+++ b/src/main/java/com/backend/Artview/domain/exhibition/service/ExhibitionService.java
@@ -1,9 +1,17 @@
 package com.backend.Artview.domain.exhibition.service;
 
+import com.backend.Artview.domain.exhibition.dto.response.ExhibitionDetailInfoResponseDto;
+import com.backend.Artview.domain.exhibition.dto.response.ExhibitionDetailReviewResponseDto;
 import com.backend.Artview.domain.exhibition.dto.response.ExhibitionResponseDto;
+
+import java.util.List;
 
 public interface ExhibitionService {
     ExhibitionResponseDto findOngoingExhibition(Long cursor);
 
     ExhibitionResponseDto findFreeExhibition(Long cursor);
+
+    ExhibitionDetailInfoResponseDto findExhibitionDetailInfo(Long exhibitionId);
+
+    List<ExhibitionDetailReviewResponseDto> findExhibitionDetailReview(Long exhibitionId);
 }

--- a/src/main/java/com/backend/Artview/domain/exhibition/service/ExhibitionServiceImpl.java
+++ b/src/main/java/com/backend/Artview/domain/exhibition/service/ExhibitionServiceImpl.java
@@ -1,8 +1,13 @@
 package com.backend.Artview.domain.exhibition.service;
 
+import com.backend.Artview.domain.communication.Repository.CommunicationsRepository;
+import com.backend.Artview.domain.communication.domain.Communications;
 import com.backend.Artview.domain.exhibition.domain.CrawlingExhibition;
+import com.backend.Artview.domain.exhibition.dto.response.ExhibitionDetailInfoResponseDto;
+import com.backend.Artview.domain.exhibition.dto.response.ExhibitionDetailReviewResponseDto;
 import com.backend.Artview.domain.exhibition.dto.response.ExhibitionInfo;
 import com.backend.Artview.domain.exhibition.dto.response.ExhibitionResponseDto;
+import com.backend.Artview.domain.exhibition.exception.ExhibitionException;
 import com.backend.Artview.domain.exhibition.repository.CrawlingExhibitionRepository;
 import com.backend.Artview.global.util.PaginationUtil;
 import jakarta.transaction.Transactional;
@@ -11,16 +16,21 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.backend.Artview.domain.exhibition.domain.ExhibitionType.*;
+import static com.backend.Artview.domain.exhibition.exception.ExhibitionErrorCode.EXHIBITION_NOT_FOUND;
+import static com.backend.Artview.domain.exhibition.exception.ExhibitionErrorCode.EXHIBITION_REVIEWS_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
 public class ExhibitionServiceImpl implements ExhibitionService {
 
     private final CrawlingExhibitionRepository crawlingExhibitionRepository;
+    private final CommunicationsRepository communicationsRepository;
     private final PaginationUtil paginationUtil;
     private final int DEFAULT_PAGE_SIZE = 6;
 
@@ -33,7 +43,31 @@ public class ExhibitionServiceImpl implements ExhibitionService {
     @Override
     @Transactional
     public ExhibitionResponseDto findFreeExhibition(Long cursor) {
-        return findExhibitionsByType(cursor,FREE.getCode());
+        return findExhibitionsByType(cursor, FREE.getCode());
+    }
+
+    @Override
+    @Transactional
+    public ExhibitionDetailInfoResponseDto findExhibitionDetailInfo(Long exhibitionId) {
+        CrawlingExhibition exhibition = findExhibitionById(exhibitionId);
+        return ExhibitionDetailInfoResponseDto.of(exhibition);
+    }
+
+
+    @Override
+    @Transactional
+    public List<ExhibitionDetailReviewResponseDto> findExhibitionDetailReview(Long exhibitionId) {
+
+        List<Communications> communications = findCommunicationsByExhibitionId(exhibitionId);
+        return communications.stream().map(ExhibitionDetailReviewResponseDto::of).collect(Collectors.toList());
+    }
+
+    private List<Communications> findCommunicationsByExhibitionId(Long exhibitionId) {
+        return communicationsRepository.findAllByCrawlingExhibitionId(exhibitionId);
+    }
+
+    private CrawlingExhibition findExhibitionById(Long exhibitionId) {
+        return crawlingExhibitionRepository.findById(exhibitionId).orElseThrow(() -> new ExhibitionException(EXHIBITION_NOT_FOUND));
     }
 
     private ExhibitionResponseDto findExhibitionsByType(Long cursor, String progressType) {

--- a/src/main/java/com/backend/Artview/domain/myReviews/domain/MyReviews.java
+++ b/src/main/java/com/backend/Artview/domain/myReviews/domain/MyReviews.java
@@ -1,5 +1,6 @@
 package com.backend.Artview.domain.myReviews.domain;
 
+import com.backend.Artview.domain.exhibition.domain.CrawlingExhibition;
 import com.backend.Artview.domain.myReviews.dto.request.MyReviewsModifyRequestDto;
 import com.backend.Artview.domain.myReviews.dto.request.MyReviewsSaveRequestDto;
 import com.backend.Artview.domain.users.domain.Users;
@@ -49,7 +50,11 @@ public class MyReviews extends BaseEntity {
     @OneToMany(mappedBy = "myReviews", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<MyReviewsContents> myReviewsContents = new ArrayList<>();
 
-    public static MyReviews toEntity(MyReviewsSaveRequestDto requestDto, String mainImageUrlFromS3 , Users users) {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "crawling_exhibition_id")
+    private CrawlingExhibition crawlingExhibition;
+
+    public static MyReviews toEntity(MyReviewsSaveRequestDto requestDto, String mainImageUrlFromS3 , Users users, CrawlingExhibition crawlingExhibition) {
         return MyReviews.builder()
                 .exhibitionsTitle(requestDto.getName())
                 .exhibitionsLocation(requestDto.getGallery())
@@ -58,6 +63,7 @@ public class MyReviews extends BaseEntity {
                 .mainImageUrl(mainImageUrlFromS3)
                 .users(users)
                 .myReviewsContents(new ArrayList<>())
+                .crawlingExhibition(crawlingExhibition)
                 .build();
     }
 

--- a/src/main/java/com/backend/Artview/domain/myReviews/dto/request/MyReviewsSaveRequestDto.java
+++ b/src/main/java/com/backend/Artview/domain/myReviews/dto/request/MyReviewsSaveRequestDto.java
@@ -16,4 +16,5 @@ public class MyReviewsSaveRequestDto {
     MultipartFile mainImage;
     String rating;
     List<SaveRequestArtList> artList;
+    Long exhibitionId;
 }

--- a/src/main/java/com/backend/Artview/domain/myReviews/service/MyReviewsServiceImpl.java
+++ b/src/main/java/com/backend/Artview/domain/myReviews/service/MyReviewsServiceImpl.java
@@ -1,6 +1,8 @@
 package com.backend.Artview.domain.myReviews.service;
 
 
+import com.backend.Artview.domain.exhibition.domain.CrawlingExhibition;
+import com.backend.Artview.domain.exhibition.repository.CrawlingExhibitionRepository;
 import com.backend.Artview.domain.myReviews.domain.MyExhibitionImages;
 import com.backend.Artview.domain.myReviews.domain.MyReviews;
 import com.backend.Artview.domain.myReviews.domain.MyReviewsContents;
@@ -22,6 +24,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.backend.Artview.domain.myReviews.exception.MyReviewsErrorCode.IMAGE_TYPE_INCORRECT;
@@ -37,6 +40,7 @@ public class MyReviewsServiceImpl implements MyReviewsService {
     private final MyReviewsRepository myReviewsRepository;
     private final UsersRepository usersRepository;
     private final S3Util s3Util;
+    private final CrawlingExhibitionRepository crawlingExhibitionRepository;
 
     @Override
     @Transactional
@@ -72,7 +76,8 @@ public class MyReviewsServiceImpl implements MyReviewsService {
     public Long saveMyReviews(Long userId, MyReviewsSaveRequestDto requestDto) {
 
         Users user = usersRepository.findById(userId).orElseThrow(() -> new UserException(USER_NOT_FOUND));
-        MyReviews myReviews = MyReviews.toEntity(requestDto, uploadImageUrlToS3(requestDto.getMainImage()) ,user);
+        CrawlingExhibition crawlingExhibition = findCrawlingExhibition(requestDto.getExhibitionId());
+        MyReviews myReviews = MyReviews.toEntity(requestDto, uploadImageUrlToS3(requestDto.getMainImage()) ,user, crawlingExhibition);
 
         for(int i = 0; i<requestDto.getArtList().size(); i++) {
             MyReviewsContents myReviewsContents = addMyReviewsContentToMyReviews(myReviews, requestDto.getArtList().get(i));
@@ -80,6 +85,10 @@ public class MyReviewsServiceImpl implements MyReviewsService {
         }
 
         return myReviewsRepository.save(myReviews).getId();
+    }
+
+    private CrawlingExhibition findCrawlingExhibition(Long exhibitionId){
+        return crawlingExhibitionRepository.findById(exhibitionId).orElse(null);
     }
 
 //    @Override

--- a/src/main/java/com/backend/Artview/domain/users/controller/UserController.java
+++ b/src/main/java/com/backend/Artview/domain/users/controller/UserController.java
@@ -59,6 +59,11 @@ public class UserController {
         return userService.findMyPageMyFollowerList(userId);
     }
 
+    @GetMapping("/myPage/interest")
+    public List<String> findUsersInterest(@UserId Long userId){
+        return userService.findUsersInterest(userId);
+    }
+
     @PatchMapping("/modify/myPage")
     public void modifyMyPageInfo(@UserId Long userId, @ModelAttribute ModifyMyPageInfoRequestDto dto){
         userService.modifyMyPageInfo(userId, dto);
@@ -93,6 +98,15 @@ public class UserController {
     @GetMapping("/checkFollow/{writerId}")
     public boolean checkUsersFollow(@UserId Long userId, @PathVariable Long writerId) {
         return userService.checkUsersFollow(userId, writerId);
+    }
+
+    @GetMapping("/FollowingList/{writerId}")
+    public List<MyPageFollowInfoDto> findWriterMyFollowingList(@PathVariable Long writerId){
+        return userService.findMyPageMyFollowingList(writerId);
+    }
+    @GetMapping("/FollowerList/{writerId}")
+    public List<MyPageFollowInfoDto> findWriterMyFollowerList(@PathVariable Long writerId){
+        return userService.findMyPageMyFollowerList(writerId);
     }
 //    다른 사용자 프로필 조회 api
 

--- a/src/main/java/com/backend/Artview/domain/users/service/UserService.java
+++ b/src/main/java/com/backend/Artview/domain/users/service/UserService.java
@@ -30,4 +30,6 @@ public interface UserService {
     void modifyMyPageInfo(Long userId, ModifyMyPageInfoRequestDto dto);
 
     void saveUsersInterest(Long userId, SaveUsersInterestRequestDto dto);
+
+    List<String> findUsersInterest(Long userId);
 }

--- a/src/main/java/com/backend/Artview/domain/users/service/UserServiceImpl.java
+++ b/src/main/java/com/backend/Artview/domain/users/service/UserServiceImpl.java
@@ -161,6 +161,13 @@ public class UserServiceImpl implements UserService {
         saveUsersInterest(usersInterestList);
     }
 
+    @Override
+    @Transactional
+    public List<String> findUsersInterest(Long userId) {
+        List<UsersInterest> usersInterests = findUsersById(userId).getUsersInterests();
+        return usersInterests.stream().map(UsersInterest::getUsersInterestContent).collect(Collectors.toList());
+    }
+
     private void ifUsersAlreadySaveInterestThenDelete(Users users) {
         if (isUsersAlreadySaveInterest(users)) {
             deleteInterestsByUsers(users);

--- a/src/main/java/com/backend/Artview/global/util/StringUtil.java
+++ b/src/main/java/com/backend/Artview/global/util/StringUtil.java
@@ -5,6 +5,9 @@ import org.springframework.stereotype.Component;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 @Component
 public class StringUtil {
@@ -20,4 +23,7 @@ public class StringUtil {
         return otherDate;
     }
 
+    public static List<String> removeTextFromSentence(String sentence, String removeText){
+        return Arrays.asList(sentence.split(removeText));
+    }
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 코드 리팩토링

---

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 전시정보 상세페이지 api, 소통
- 리뷰에 전시회id 추가
- 진행예정인 전시 -> 무료 전시로 변경

---

## ✏️ 관련 이슈
본인이 작업한 내용이 어떤 Issue Number와 관련이 있는지만 작성해주세요

ex)
- Feat : #79  
- Refactor : #76 

---

## 🎸 기타 사항 or 추가 코멘트
![전시회 정보 화면](https://github.com/user-attachments/assets/810ef867-272b-43ce-9cd3-e3256ae9886e)
