### PR TITLE
[feat] 전시회/기록 페이지 검색 기능 구현

### DIFF
--- a/src/main/java/com/backend/Artview/domain/communication/service/CommunicationsServiceImpl.java
+++ b/src/main/java/com/backend/Artview/domain/communication/service/CommunicationsServiceImpl.java
@@ -19,7 +19,7 @@ import com.backend.Artview.domain.myReviews.repository.MyReviewsRepository;
 import com.backend.Artview.domain.users.domain.Users;
 import com.backend.Artview.domain.users.exception.UserException;
 import com.backend.Artview.domain.users.repository.UsersRepository;
-import com.backend.Artview.global.util.PaginationUtil;
+import com.backend.Artview.global.pagination.PaginationUtil;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;

--- a/src/main/java/com/backend/Artview/domain/exhibition/controller/ExhibitionController.java
+++ b/src/main/java/com/backend/Artview/domain/exhibition/controller/ExhibitionController.java
@@ -3,6 +3,7 @@ package com.backend.Artview.domain.exhibition.controller;
 import com.backend.Artview.domain.exhibition.dto.response.ExhibitionDetailInfoResponseDto;
 import com.backend.Artview.domain.exhibition.dto.response.ExhibitionDetailReviewResponseDto;
 import com.backend.Artview.domain.exhibition.dto.response.ExhibitionResponseDto;
+import com.backend.Artview.domain.exhibition.dto.response.SearchExhibitionInfoResponseDto;
 import com.backend.Artview.domain.exhibition.service.ExhibitionService;
 import com.backend.Artview.domain.exhibition.service.ExhibitionServiceImpl;
 import com.backend.Artview.domain.users.dto.response.MyPageFollowAndMyReviewsNumberInfoResponseDto;
@@ -21,7 +22,6 @@ import java.util.List;
 public class ExhibitionController {
 
     private final ExhibitionService exhibitionService;
-    private final UserService userService;
 
     @GetMapping("/free/{cursor}")
     public ExhibitionResponseDto findFreeExhibition(@PathVariable Long cursor) {
@@ -41,5 +41,10 @@ public class ExhibitionController {
     @GetMapping("/detail/review/{exhibitionId}")
     public List<ExhibitionDetailReviewResponseDto> findExhibitionDetailReview(@PathVariable Long exhibitionId) {
        return exhibitionService.findExhibitionDetailReview(exhibitionId);
+    }
+
+    @GetMapping("/search/{keyword}/{cursor}")
+    public ExhibitionSearchKeywordResponseDto searchExhibitionInfoByKeyword(@PathVariable(name = "keyword") String keyword, @PathVariable(name = "cursor") Long cursor){
+        return exhibitionService.searchExhibitionInfoByKeyword(keyword, cursor);
     }
 }

--- a/src/main/java/com/backend/Artview/domain/exhibition/controller/ExhibitionController.java
+++ b/src/main/java/com/backend/Artview/domain/exhibition/controller/ExhibitionController.java
@@ -1,16 +1,10 @@
 package com.backend.Artview.domain.exhibition.controller;
 
+import com.backend.Artview.domain.exhibition.dto.response.ExhibitionSearchKeywordResponseDto;
 import com.backend.Artview.domain.exhibition.dto.response.ExhibitionDetailInfoResponseDto;
 import com.backend.Artview.domain.exhibition.dto.response.ExhibitionDetailReviewResponseDto;
 import com.backend.Artview.domain.exhibition.dto.response.ExhibitionResponseDto;
-import com.backend.Artview.domain.exhibition.dto.response.SearchExhibitionInfoResponseDto;
 import com.backend.Artview.domain.exhibition.service.ExhibitionService;
-import com.backend.Artview.domain.exhibition.service.ExhibitionServiceImpl;
-import com.backend.Artview.domain.users.dto.response.MyPageFollowAndMyReviewsNumberInfoResponseDto;
-import com.backend.Artview.domain.users.dto.response.MyPageMyReviewsAndCommunicationsResponseDto;
-import com.backend.Artview.domain.users.dto.response.MyPageUserInfoResponseDto;
-import com.backend.Artview.domain.users.service.UserService;
-import com.backend.Artview.global.customAnnotation.UserId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/com/backend/Artview/domain/exhibition/controller/ExhibitionSearchKeywordResponseDto.java
+++ b/src/main/java/com/backend/Artview/domain/exhibition/controller/ExhibitionSearchKeywordResponseDto.java
@@ -1,0 +1,22 @@
+package com.backend.Artview.domain.exhibition.controller;
+
+import com.backend.Artview.domain.exhibition.domain.CrawlingExhibition;
+import com.backend.Artview.domain.exhibition.dto.response.ExhibitionDetailInfoResponseDto;
+import com.backend.Artview.global.pagination.PaginationNextInfoDto;
+import lombok.Builder;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+@Builder
+public record ExhibitionSearchKeywordResponseDto(
+        List<ExhibitionDetailInfoResponseDto> exhibitionDetailInfo,
+        PaginationNextInfoDto paginationNextInfoDto
+) {
+    public static ExhibitionSearchKeywordResponseDto of(List<ExhibitionDetailInfoResponseDto> exhibitionDetailInfo, Slice<CrawlingExhibition> crawlingExhibitionList, Long nextCursor){
+        return ExhibitionSearchKeywordResponseDto.builder()
+                .exhibitionDetailInfo(exhibitionDetailInfo)
+                .paginationNextInfoDto(PaginationNextInfoDto.of(crawlingExhibitionList.hasNext(), crawlingExhibitionList.getNumberOfElements(),nextCursor))
+                .build();
+    }
+}

--- a/src/main/java/com/backend/Artview/domain/exhibition/domain/ExhibitionType.java
+++ b/src/main/java/com/backend/Artview/domain/exhibition/domain/ExhibitionType.java
@@ -4,7 +4,8 @@ public enum ExhibitionType {
     UPCOMING("0"),
     ONGOING("1"),
     COMPLETED("2"),
-    FREE("3");
+    FREE("3"),
+    ONLINE("4");
 
     private final String code;
 

--- a/src/main/java/com/backend/Artview/domain/exhibition/dto/response/ExhibitionDetailInfoResponseDto.java
+++ b/src/main/java/com/backend/Artview/domain/exhibition/dto/response/ExhibitionDetailInfoResponseDto.java
@@ -5,8 +5,7 @@ import lombok.Builder;
 
 import java.util.List;
 
-import static com.backend.Artview.domain.exhibition.domain.ExhibitionType.FREE;
-import static com.backend.Artview.domain.exhibition.domain.ExhibitionType.ONGOING;
+import static com.backend.Artview.domain.exhibition.domain.ExhibitionType.*;
 import static com.backend.Artview.global.util.StringUtil.removeTextFromSentence;
 
 @Builder
@@ -27,7 +26,7 @@ public record ExhibitionDetailInfoResponseDto(
     }
 
     private static boolean checkExhibitionProgressType(String progressType) {
-        return (progressType.equals(ONGOING.getCode()) || progressType.equals(FREE.getCode()));
+        return (!progressType.equals(COMPLETED.getCode()));
     }
 
     private static boolean checkOperatingHours(String operatingHours){

--- a/src/main/java/com/backend/Artview/domain/exhibition/dto/response/ExhibitionResponseDto.java
+++ b/src/main/java/com/backend/Artview/domain/exhibition/dto/response/ExhibitionResponseDto.java
@@ -1,6 +1,7 @@
 package com.backend.Artview.domain.exhibition.dto.response;
 
 import com.backend.Artview.domain.exhibition.domain.CrawlingExhibition;
+import com.backend.Artview.global.pagination.PaginationNextInfoDto;
 import lombok.Builder;
 import org.springframework.data.domain.Slice;
 
@@ -9,17 +10,14 @@ import java.util.List;
 @Builder
 public record ExhibitionResponseDto(
         List<ExhibitionInfo> exhibitionInfos,
-        boolean hasNext,
-        int numberOfElements,
-        Long nextCursor
+        PaginationNextInfoDto nextInfoDto
+
 ) {
 
     public static ExhibitionResponseDto of(List<ExhibitionInfo> dtoList, Slice<CrawlingExhibition> exhibitionInfos, Long nextCursor){
         return ExhibitionResponseDto.builder()
                 .exhibitionInfos(dtoList)
-                .hasNext(exhibitionInfos.hasNext())
-                .numberOfElements(exhibitionInfos.getNumberOfElements())
-                .nextCursor(nextCursor)
+                .nextInfoDto(PaginationNextInfoDto.of(exhibitionInfos.hasNext(),exhibitionInfos.getNumberOfElements(),nextCursor))
                 .build();
     }
 

--- a/src/main/java/com/backend/Artview/domain/exhibition/dto/response/ExhibitionSearchKeywordResponseDto.java
+++ b/src/main/java/com/backend/Artview/domain/exhibition/dto/response/ExhibitionSearchKeywordResponseDto.java
@@ -1,7 +1,6 @@
-package com.backend.Artview.domain.exhibition.controller;
+package com.backend.Artview.domain.exhibition.dto.response;
 
 import com.backend.Artview.domain.exhibition.domain.CrawlingExhibition;
-import com.backend.Artview.domain.exhibition.dto.response.ExhibitionDetailInfoResponseDto;
 import com.backend.Artview.global.pagination.PaginationNextInfoDto;
 import lombok.Builder;
 import org.springframework.data.domain.Slice;

--- a/src/main/java/com/backend/Artview/domain/exhibition/dto/response/SearchExhibitionInfoResponseDto.java
+++ b/src/main/java/com/backend/Artview/domain/exhibition/dto/response/SearchExhibitionInfoResponseDto.java
@@ -1,0 +1,9 @@
+package com.backend.Artview.domain.exhibition.dto.response;
+
+public record SearchExhibitionInfoResponseDto(
+
+
+
+
+) {
+}

--- a/src/main/java/com/backend/Artview/domain/exhibition/repository/CrawlingExhibitionRepository.java
+++ b/src/main/java/com/backend/Artview/domain/exhibition/repository/CrawlingExhibitionRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CrawlingExhibitionRepository extends JpaRepository<CrawlingExhibition, Long> {
 
@@ -20,4 +21,14 @@ public interface CrawlingExhibitionRepository extends JpaRepository<CrawlingExhi
             "SELECT ce FROM CrawlingExhibition ce WHERE ce.id < :cursor AND ce.progressType = :progressType"
     )
     Slice<CrawlingExhibition> findCrawlingExhibitionByCursorTopByAndProgressTypeOrderByStartDateDesc(@Param(value = "cursor")Long cursor, PageRequest pageRequest, String progressType);
+
+    @Query(
+            "SELECT ce FROM CrawlingExhibition ce WHERE ce.title LIKE %:keyword% or ce.location LIKE %:keyword% Order By ce.id DESC"
+    )
+        Slice<CrawlingExhibition> findAllByKeyword(PageRequest pageRequest, String keyword);
+
+    @Query(
+            "SELECT ce FROM CrawlingExhibition ce WHERE ce.id < :cursor AND ce.title LIKE %:keyword% or ce.location LIKE %:keyword% Order By ce.id DESC"
+    )
+    Slice<CrawlingExhibition> findAllByKeyword(@Param(value = "cursor")Long cursor, PageRequest pageRequest, String keyword);
 }

--- a/src/main/java/com/backend/Artview/domain/exhibition/repository/CrawlingExhibitionRepository.java
+++ b/src/main/java/com/backend/Artview/domain/exhibition/repository/CrawlingExhibitionRepository.java
@@ -20,15 +20,20 @@ public interface CrawlingExhibitionRepository extends JpaRepository<CrawlingExhi
     @Query(
             "SELECT ce FROM CrawlingExhibition ce WHERE ce.id < :cursor AND ce.progressType = :progressType"
     )
-    Slice<CrawlingExhibition> findCrawlingExhibitionByCursorTopByAndProgressTypeOrderByStartDateDesc(@Param(value = "cursor")Long cursor, PageRequest pageRequest, String progressType);
+    Slice<CrawlingExhibition> findCrawlingExhibitionByCursorTopByAndProgressTypeOrderByStartDateDesc(@Param(value = "cursor") Long cursor, PageRequest pageRequest, String progressType);
 
     @Query(
             "SELECT ce FROM CrawlingExhibition ce WHERE ce.title LIKE %:keyword% or ce.location LIKE %:keyword% Order By ce.id DESC"
     )
-        Slice<CrawlingExhibition> findAllByKeyword(PageRequest pageRequest, String keyword);
+    Slice<CrawlingExhibition> findAllExhibitionByKeyword(PageRequest pageRequest, String keyword);
+
+    @Query(
+            "SELECT ce FROM CrawlingExhibition ce WHERE ce.title LIKE %:keyword% Order By ce.id DESC"
+    )
+    List<CrawlingExhibition> findAllExhibitionByKeyword(String keyword);
 
     @Query(
             "SELECT ce FROM CrawlingExhibition ce WHERE ce.id < :cursor AND ce.title LIKE %:keyword% or ce.location LIKE %:keyword% Order By ce.id DESC"
     )
-    Slice<CrawlingExhibition> findAllByKeyword(@Param(value = "cursor")Long cursor, PageRequest pageRequest, String keyword);
+    Slice<CrawlingExhibition> findAllByKeyword(@Param(value = "cursor") Long cursor, PageRequest pageRequest, String keyword);
 }

--- a/src/main/java/com/backend/Artview/domain/exhibition/service/ExhibitionService.java
+++ b/src/main/java/com/backend/Artview/domain/exhibition/service/ExhibitionService.java
@@ -1,6 +1,6 @@
 package com.backend.Artview.domain.exhibition.service;
 
-import com.backend.Artview.domain.exhibition.controller.ExhibitionSearchKeywordResponseDto;
+import com.backend.Artview.domain.exhibition.dto.response.ExhibitionSearchKeywordResponseDto;
 import com.backend.Artview.domain.exhibition.dto.response.ExhibitionDetailInfoResponseDto;
 import com.backend.Artview.domain.exhibition.dto.response.ExhibitionDetailReviewResponseDto;
 import com.backend.Artview.domain.exhibition.dto.response.ExhibitionResponseDto;

--- a/src/main/java/com/backend/Artview/domain/exhibition/service/ExhibitionService.java
+++ b/src/main/java/com/backend/Artview/domain/exhibition/service/ExhibitionService.java
@@ -1,5 +1,6 @@
 package com.backend.Artview.domain.exhibition.service;
 
+import com.backend.Artview.domain.exhibition.controller.ExhibitionSearchKeywordResponseDto;
 import com.backend.Artview.domain.exhibition.dto.response.ExhibitionDetailInfoResponseDto;
 import com.backend.Artview.domain.exhibition.dto.response.ExhibitionDetailReviewResponseDto;
 import com.backend.Artview.domain.exhibition.dto.response.ExhibitionResponseDto;
@@ -14,4 +15,6 @@ public interface ExhibitionService {
     ExhibitionDetailInfoResponseDto findExhibitionDetailInfo(Long exhibitionId);
 
     List<ExhibitionDetailReviewResponseDto> findExhibitionDetailReview(Long exhibitionId);
+
+    ExhibitionSearchKeywordResponseDto searchExhibitionInfoByKeyword(String keyword, Long cursor);
 }

--- a/src/main/java/com/backend/Artview/domain/exhibition/service/ExhibitionServiceImpl.java
+++ b/src/main/java/com/backend/Artview/domain/exhibition/service/ExhibitionServiceImpl.java
@@ -2,6 +2,7 @@ package com.backend.Artview.domain.exhibition.service;
 
 import com.backend.Artview.domain.communication.Repository.CommunicationsRepository;
 import com.backend.Artview.domain.communication.domain.Communications;
+import com.backend.Artview.domain.exhibition.controller.ExhibitionSearchKeywordResponseDto;
 import com.backend.Artview.domain.exhibition.domain.CrawlingExhibition;
 import com.backend.Artview.domain.exhibition.dto.response.ExhibitionDetailInfoResponseDto;
 import com.backend.Artview.domain.exhibition.dto.response.ExhibitionDetailReviewResponseDto;
@@ -9,21 +10,19 @@ import com.backend.Artview.domain.exhibition.dto.response.ExhibitionInfo;
 import com.backend.Artview.domain.exhibition.dto.response.ExhibitionResponseDto;
 import com.backend.Artview.domain.exhibition.exception.ExhibitionException;
 import com.backend.Artview.domain.exhibition.repository.CrawlingExhibitionRepository;
-import com.backend.Artview.global.util.PaginationUtil;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.backend.Artview.domain.exhibition.domain.ExhibitionType.*;
 import static com.backend.Artview.domain.exhibition.exception.ExhibitionErrorCode.EXHIBITION_NOT_FOUND;
-import static com.backend.Artview.domain.exhibition.exception.ExhibitionErrorCode.EXHIBITION_REVIEWS_NOT_FOUND;
+import static com.backend.Artview.global.pagination.PaginationUtil.createPageRequest;
 
 @Service
 @RequiredArgsConstructor
@@ -31,7 +30,6 @@ public class ExhibitionServiceImpl implements ExhibitionService {
 
     private final CrawlingExhibitionRepository crawlingExhibitionRepository;
     private final CommunicationsRepository communicationsRepository;
-    private final PaginationUtil paginationUtil;
     private final int DEFAULT_PAGE_SIZE = 6;
 
     @Override
@@ -57,9 +55,20 @@ public class ExhibitionServiceImpl implements ExhibitionService {
     @Override
     @Transactional
     public List<ExhibitionDetailReviewResponseDto> findExhibitionDetailReview(Long exhibitionId) {
-
         List<Communications> communications = findCommunicationsByExhibitionId(exhibitionId);
         return communications.stream().map(ExhibitionDetailReviewResponseDto::of).collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public ExhibitionSearchKeywordResponseDto searchExhibitionInfoByKeyword(String keyword, Long cursor) {
+        PageRequest pageRequest = createPageRequest(DEFAULT_PAGE_SIZE);
+        Slice<CrawlingExhibition> crawlingExhibitionList = cursor == 0 ? crawlingExhibitionRepository.findAllByKeyword(pageRequest,keyword) :
+         crawlingExhibitionRepository.findAllByKeyword(cursor, pageRequest,keyword);
+        Long nextCursor = checkHaveNextCursor(crawlingExhibitionList);
+        if (crawlingExhibitionList.isEmpty()) return null;
+        List<ExhibitionDetailInfoResponseDto> exhibitionDetailInfo = crawlingExhibitionList.stream().map(ExhibitionDetailInfoResponseDto::of).toList();
+        return ExhibitionSearchKeywordResponseDto.of(exhibitionDetailInfo, crawlingExhibitionList, nextCursor);
     }
 
     private List<Communications> findCommunicationsByExhibitionId(Long exhibitionId) {
@@ -71,7 +80,7 @@ public class ExhibitionServiceImpl implements ExhibitionService {
     }
 
     private ExhibitionResponseDto findExhibitionsByType(Long cursor, String progressType) {
-        PageRequest pageRequest = createPageRequest();
+        PageRequest pageRequest = createPageRequest(DEFAULT_PAGE_SIZE,"id");
 
         Slice<CrawlingExhibition> crawlingExhibitionList = cursor == 0 ? crawlingExhibitionRepository.findCrawlingExhibitionTopByProgressTypeOrderByStartDateDesc(pageRequest, progressType)
                 : crawlingExhibitionRepository.findCrawlingExhibitionByCursorTopByAndProgressTypeOrderByStartDateDesc(cursor, pageRequest, progressType);
@@ -80,10 +89,6 @@ public class ExhibitionServiceImpl implements ExhibitionService {
 
         Long nextCursor = checkHaveNextCursor(crawlingExhibitionList);
         return ExhibitionResponseDto.of(exhibitionInfoList, crawlingExhibitionList, nextCursor);
-    }
-
-    private PageRequest createPageRequest() {
-        return paginationUtil.createPageRequest(DEFAULT_PAGE_SIZE, "id");
     }
 
     private Long checkHaveNextCursor(Slice<CrawlingExhibition> exhibitionsList) {

--- a/src/main/java/com/backend/Artview/domain/exhibition/service/ExhibitionServiceImpl.java
+++ b/src/main/java/com/backend/Artview/domain/exhibition/service/ExhibitionServiceImpl.java
@@ -2,7 +2,7 @@ package com.backend.Artview.domain.exhibition.service;
 
 import com.backend.Artview.domain.communication.Repository.CommunicationsRepository;
 import com.backend.Artview.domain.communication.domain.Communications;
-import com.backend.Artview.domain.exhibition.controller.ExhibitionSearchKeywordResponseDto;
+import com.backend.Artview.domain.exhibition.dto.response.ExhibitionSearchKeywordResponseDto;
 import com.backend.Artview.domain.exhibition.domain.CrawlingExhibition;
 import com.backend.Artview.domain.exhibition.dto.response.ExhibitionDetailInfoResponseDto;
 import com.backend.Artview.domain.exhibition.dto.response.ExhibitionDetailReviewResponseDto;
@@ -17,7 +17,6 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.backend.Artview.domain.exhibition.domain.ExhibitionType.*;
@@ -63,7 +62,7 @@ public class ExhibitionServiceImpl implements ExhibitionService {
     @Transactional
     public ExhibitionSearchKeywordResponseDto searchExhibitionInfoByKeyword(String keyword, Long cursor) {
         PageRequest pageRequest = createPageRequest(DEFAULT_PAGE_SIZE);
-        Slice<CrawlingExhibition> crawlingExhibitionList = cursor == 0 ? crawlingExhibitionRepository.findAllByKeyword(pageRequest,keyword) :
+        Slice<CrawlingExhibition> crawlingExhibitionList = cursor == 0 ? crawlingExhibitionRepository.findAllExhibitionByKeyword(pageRequest,keyword) :
          crawlingExhibitionRepository.findAllByKeyword(cursor, pageRequest,keyword);
         Long nextCursor = checkHaveNextCursor(crawlingExhibitionList);
         if (crawlingExhibitionList.isEmpty()) return null;

--- a/src/main/java/com/backend/Artview/domain/myReviews/controller/MyReviewExhibitionInfoResDto.java
+++ b/src/main/java/com/backend/Artview/domain/myReviews/controller/MyReviewExhibitionInfoResDto.java
@@ -1,0 +1,24 @@
+package com.backend.Artview.domain.myReviews.controller;
+
+import com.backend.Artview.domain.exhibition.domain.CrawlingExhibition;
+import lombok.Builder;
+
+@Builder
+public record MyReviewExhibitionInfoResDto(
+        Long exhibitionId,
+        String exhibition
+) {
+    public static MyReviewExhibitionInfoResDto ofTitle(CrawlingExhibition crawlingExhibition){
+        return MyReviewExhibitionInfoResDto.builder()
+                .exhibitionId(crawlingExhibition.getId())
+                .exhibition(crawlingExhibition.getTitle())
+                .build();
+    }
+
+    public static MyReviewExhibitionInfoResDto ofLocation(CrawlingExhibition crawlingExhibition){
+        return MyReviewExhibitionInfoResDto.builder()
+                .exhibitionId(crawlingExhibition.getId())
+                .exhibition(crawlingExhibition.getLocation())
+                .build();
+    }
+}

--- a/src/main/java/com/backend/Artview/domain/myReviews/controller/MyReviewsController.java
+++ b/src/main/java/com/backend/Artview/domain/myReviews/controller/MyReviewsController.java
@@ -51,9 +51,14 @@ public class MyReviewsController {
     }
 
     //전시회 위치 자동 반영 api
-    @GetMapping("/exhibition/{keyword}")
-    public List<> findExhibitionLocationByKeyword(@PathVariable String keyword){
-        myReviewsService.findExhibitionLocationByKeyword(keyword);
+    @GetMapping("/exhibition_title/{keyword}")
+    public List<MyReviewExhibitionInfoResDto> findExhibitionTitleByKeyword(@PathVariable String keyword){
+        return myReviewsService.findExhibitionTitleByKeyword(keyword);
+    }
+
+    @GetMapping("/exhibition_location/{exhibitionId}")
+    public MyReviewExhibitionInfoResDto findExhibitionLocationByKeyword(@PathVariable Long exhibitionId){
+        return myReviewsService.findExhibitionLocationByKeyword(exhibitionId);
     }
 
     //전시 기록 작성하기(등록하기)

--- a/src/main/java/com/backend/Artview/domain/myReviews/controller/MyReviewsController.java
+++ b/src/main/java/com/backend/Artview/domain/myReviews/controller/MyReviewsController.java
@@ -1,5 +1,6 @@
 package com.backend.Artview.domain.myReviews.controller;
 
+import com.backend.Artview.domain.exhibition.repository.CrawlingExhibitionRepository;
 import com.backend.Artview.domain.myReviews.dto.request.MyReviewsModifyRequestDto;
 import com.backend.Artview.domain.myReviews.dto.request.MyReviewsSaveRequestDto;
 import com.backend.Artview.domain.myReviews.dto.request.TestDto;
@@ -46,6 +47,12 @@ public class MyReviewsController {
     @PatchMapping("/modify")
     public void refactorMyReviews(@UserId Long userId, @ModelAttribute MyReviewsModifyRequestDto requestDto){
         myReviewsService.refactorMyReviews(userId, requestDto);
+    }
+
+    //전시회 위치 자동 반영 api
+    @GetMapping("/exhibition/{keyword}")
+    public List<> findExhibitionLocationByKeyword(@PathVariable String keyword){
+        myReviewsService.findExhibitionLocationByKeyword(keyword);
     }
 
     //전시 기록 작성하기(등록하기)

--- a/src/main/java/com/backend/Artview/domain/myReviews/dto/request/TestDto.java
+++ b/src/main/java/com/backend/Artview/domain/myReviews/dto/request/TestDto.java
@@ -30,12 +30,6 @@ import java.util.List;
 @Getter
 @Setter
 public class TestDto {
-        Long id;
-        String name;
-        String date;
-        String gallery;
         MultipartFile mainImage;
-        String rating;
-        List<TestRequestArtList> artList;
 }
 

--- a/src/main/java/com/backend/Artview/domain/myReviews/service/MyReviewsService.java
+++ b/src/main/java/com/backend/Artview/domain/myReviews/service/MyReviewsService.java
@@ -1,10 +1,10 @@
 package com.backend.Artview.domain.myReviews.service;
 
+import com.backend.Artview.domain.myReviews.controller.MyReviewExhibitionInfoResDto;
 import com.backend.Artview.domain.myReviews.dto.request.MyReviewsModifyRequestDto;
 import com.backend.Artview.domain.myReviews.dto.request.MyReviewsSaveRequestDto;
 import com.backend.Artview.domain.myReviews.dto.response.AllMyReviewsResponseDto;
 import com.backend.Artview.domain.myReviews.dto.response.DetailMyReviewsResponseDto;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -15,9 +15,12 @@ public interface MyReviewsService {
 
     DetailMyReviewsResponseDto findDetailMyReviews(Long reviewsId);
 
-//    Long saveMyReviews(MyReviewsSaveRequestDto requestDto, MultipartFile mainImage, List<MultipartFile> contentImages);
     Long saveMyReviews(Long userId, MyReviewsSaveRequestDto requestDto);
 
 //    void refactorMyReviews(MyReviewsModifyRequestDto requestDto, MultipartFile mainImage, List<MultipartFile> contentImages);
     void refactorMyReviews(Long userId, MyReviewsModifyRequestDto requestDto);
+
+    List<MyReviewExhibitionInfoResDto> findExhibitionTitleByKeyword(String keyword);
+
+    MyReviewExhibitionInfoResDto findExhibitionLocationByKeyword(Long exhibitionId);
 }

--- a/src/main/java/com/backend/Artview/domain/myReviews/service/MyReviewsServiceImpl.java
+++ b/src/main/java/com/backend/Artview/domain/myReviews/service/MyReviewsServiceImpl.java
@@ -2,7 +2,10 @@ package com.backend.Artview.domain.myReviews.service;
 
 
 import com.backend.Artview.domain.exhibition.domain.CrawlingExhibition;
+import com.backend.Artview.domain.exhibition.exception.ExhibitionErrorCode;
+import com.backend.Artview.domain.exhibition.exception.ExhibitionException;
 import com.backend.Artview.domain.exhibition.repository.CrawlingExhibitionRepository;
+import com.backend.Artview.domain.myReviews.controller.MyReviewExhibitionInfoResDto;
 import com.backend.Artview.domain.myReviews.domain.MyExhibitionImages;
 import com.backend.Artview.domain.myReviews.domain.MyReviews;
 import com.backend.Artview.domain.myReviews.domain.MyReviewsContents;
@@ -27,6 +30,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static com.backend.Artview.domain.exhibition.exception.ExhibitionErrorCode.EXHIBITION_NOT_FOUND;
 import static com.backend.Artview.domain.myReviews.exception.MyReviewsErrorCode.IMAGE_TYPE_INCORRECT;
 import static com.backend.Artview.domain.myReviews.exception.MyReviewsErrorCode.MY_REVIEWS_NOT_FOUND;
 import static com.backend.Artview.domain.users.exception.UserErrorCode.USER_NOT_FOUND;
@@ -85,6 +89,24 @@ public class MyReviewsServiceImpl implements MyReviewsService {
 
         updateAccordingToType(myReviews,artLists); //update타입에 따라 update를 진행
         myReviews.updateMyReviews(requestDto,distinguishImageType(requestDto.getMainImage()));
+    }
+
+    @Override
+    @Transactional
+    public List<MyReviewExhibitionInfoResDto> findExhibitionTitleByKeyword(String keyword) {
+        return crawlingExhibitionRepository.findAllExhibitionByKeyword(keyword).stream().map(MyReviewExhibitionInfoResDto::ofTitle).collect(Collectors.toList());
+
+    }
+
+    @Override
+    @Transactional
+    public MyReviewExhibitionInfoResDto findExhibitionLocationByKeyword(Long exhibitionId) {
+        CrawlingExhibition crawlingExhibition = findExhibitionById(exhibitionId);
+        return MyReviewExhibitionInfoResDto.ofLocation(crawlingExhibition);
+    }
+
+    private CrawlingExhibition findExhibitionById(Long exhibitionId) {
+        return crawlingExhibitionRepository.findById(exhibitionId).orElseThrow(() -> new ExhibitionException(EXHIBITION_NOT_FOUND));
     }
 
     public static Long checkCrawlingExhibitionIsNull(CrawlingExhibition crawlingExhibition){

--- a/src/main/java/com/backend/Artview/domain/users/service/UserServiceImpl.java
+++ b/src/main/java/com/backend/Artview/domain/users/service/UserServiceImpl.java
@@ -16,7 +16,7 @@ import com.backend.Artview.domain.users.repository.FollowRepository;
 import com.backend.Artview.domain.users.repository.UsersInterestRepository;
 import com.backend.Artview.domain.users.repository.UsersRepository;
 import com.backend.Artview.global.jwt.JwtProvider;
-import com.backend.Artview.global.util.PaginationUtil;
+import com.backend.Artview.global.pagination.PaginationUtil;
 import com.backend.Artview.global.util.S3Util;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/backend/Artview/global/pagination/PaginationNextInfoDto.java
+++ b/src/main/java/com/backend/Artview/global/pagination/PaginationNextInfoDto.java
@@ -1,0 +1,21 @@
+package com.backend.Artview.global.pagination;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class PaginationNextInfoDto{
+        public boolean hasNext;
+        public int numberOfElements;
+        public Long nextCursor;
+
+    public static PaginationNextInfoDto of(boolean hasNext, int numberOfElements, Long nextCursor) {
+        return PaginationNextInfoDto.builder()
+                .hasNext(hasNext)
+                .numberOfElements(numberOfElements)
+                .nextCursor(nextCursor)
+                .build();
+    }
+
+}

--- a/src/main/java/com/backend/Artview/global/pagination/PaginationUtil.java
+++ b/src/main/java/com/backend/Artview/global/pagination/PaginationUtil.java
@@ -1,4 +1,4 @@
-package com.backend.Artview.global.util;
+package com.backend.Artview.global.pagination;
 
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -7,7 +7,11 @@ import org.springframework.stereotype.Component;
 @Component
 public class PaginationUtil {
 
-    public PageRequest createPageRequest(int defaultPageSize, String sort) {
+    public static PageRequest createPageRequest(int defaultPageSize, String sort) {
         return PageRequest.of(0, defaultPageSize, Sort.by(sort).descending());
+    }
+
+    public static PageRequest createPageRequest(int defaultPageSize) {
+        return PageRequest.of(0, defaultPageSize);
     }
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가

---

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 전시회 페이지 검색 기능 구현
- 기록 페이지 제목 입력시 전시회 장소 검색되는 api

---

## ✏️ 관련 이슈
본인이 작업한 내용이 어떤 Issue Number와 관련이 있는지만 작성해주세요

ex)
- Feat : #72 , #80 

---

## 🎸 기타 사항 or 추가 코멘트